### PR TITLE
Fix lookups made in the wrong array

### DIFF
--- a/truegaze/plugins/weak_key.py
+++ b/truegaze/plugins/weak_key.py
@@ -101,13 +101,13 @@ class WeakKeyPlugin(BasePlugin):
         if apk._is_signed_v2:
             certs_v2 = apk.get_certificates_v2()
             for x in range(len(certs_v2)):
-                if certs_v2[x].public_key.algorithm == 'dsa' or certs_v1[x].public_key.algorithm == 'ecdsa':
+                if certs_v2[x].public_key.algorithm == 'dsa' or certs_v2[x].public_key.algorithm == 'ecdsa':
                     signatures.append(apk._v2_signing_data[x].signatures[0][1])
 
         if apk._is_signed_v3:
             certs_v3 = apk.get_certificates_v3()
             for x in range(len(certs_v3)):
-                if certs_v3[x].public_key.algorithm == 'dsa' or certs_v1[x].public_key.algorithm == 'ecdsa':
+                if certs_v3[x].public_key.algorithm == 'dsa' or certs_v3[x].public_key.algorithm == 'ecdsa':
                     signatures.append(apk._v3_signing_data[x].signatures[0][1])
 
         return signatures


### PR DESCRIPTION
Running the tool on this apk https://play.google.com/store/apps/details?id=co.clario.android results in the following error

```
Traceback (most recent call last):
  File "/home/dee-see/.local/bin/truegaze", line 8, in <module>
    sys.exit(cli())
  File "/home/dee-see/.local/lib/python3.8/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/dee-see/.local/lib/python3.8/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/dee-see/.local/lib/python3.8/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/dee-see/.local/lib/python3.8/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/dee-see/.local/lib/python3.8/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/dee-see/.local/lib/python3.8/site-packages/truegaze/cli.py", line 99, in scan
    instance.scan()
  File "/home/dee-see/.local/lib/python3.8/site-packages/truegaze/plugins/weak_key.py", line 63, in scan
    signatures = WeakKeyPlugin.get_signatures(apk)
  File "/home/dee-see/.local/lib/python3.8/site-packages/truegaze/plugins/weak_key.py", line 104, in get_signatures
    if certs_v2[x].public_key.algorithm == 'dsa' or certs_v1[x].public_key.algorithm == 'ecdsa':
IndexError: list index out of range
```

From my quick look at the code it seems like lookups were done in the wrong arrays hence the out of range error, I've corrected that in this PR.