### PR TITLE
Include ADB files with suffixes

### DIFF
--- a/truegaze/plugins/adobe_mobile_sdk.py
+++ b/truegaze/plugins/adobe_mobile_sdk.py
@@ -33,7 +33,7 @@ from truegaze.utils import TruegazeUtils
 
 # Regex pattern for the configuration file
 CONFIG_FILE_PATTERN =\
-    re.compile(r'assets/ADBMobileConfig\.json|ADBMobileConfig\.json|.*/ADBMobileConfig\.json')
+    re.compile(r'(.*/)?ADBMobileConfig(.*)\.json')
 
 # Location of the rules file for validation
 RULES_FILE = pkg_resources.resource_filename('truegaze', 'data/adobe_mobile_sdk.schema')


### PR DESCRIPTION
I was analyzing an app and it had a `ADBMobileConfig-Can.json` file, I figure I'd modify the regex to include suffixes.

I also compressed the regex into something a bit more simple. Let me know what you think!